### PR TITLE
tweak(recipe/cfg): Added endpoint privacy by default

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -13,6 +13,7 @@
 sv_maxclients {{maxClients}}
 set steam_webApiKey "none"
 sets tags "default, deployer, plume esx"
+sv_endpointPrivacy true
 
 ## You MAY edit the following:
 sv_licenseKey "{{svLicense}}"


### PR DESCRIPTION
I notice a lot of servers do not have this enabled, and a lot of servers also use PlumeESX, so I thought it might be a good addition for player privacy.